### PR TITLE
fix: only modify URLs for sitemap creation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,12 +16,13 @@ export default function(config) {
   });
   
   config.addCollection("sitemap", (collectionApi) => {
-    return collectionApi
-      .getAll()
-      .map((item, index, all) => {
-        item.url = "/help" + item.url;
-        return item;
-      });
+    return collectionApi.getAll().map((item, index, all) => {
+       return {
+         url: "/help" + item.url,
+         date: item.date,
+         data: item.data
+       };
+     });
   });
 
   // https://www.11ty.dev/docs/collections/#collection-api-methods

--- a/sitemap.njk
+++ b/sitemap.njk
@@ -3,4 +3,4 @@ permalink: /sitemap.xml
 layout: null
 eleventyExcludeFromCollections: true
 ---
-{% sitemap collections.all %}
+{% sitemap collections.sitemap %}


### PR DESCRIPTION
While adding the sitemap plugin I confused JS reference and value semantics and accidentally changed the URL for all collections and not just the sitemap collection.

This caused broken links that would result in 404s.

This PR fixes this.

I am sorry.