### PR TITLE
Update firewall doc

### DIFF
--- a/posts/configuring-your-firewall.md
+++ b/posts/configuring-your-firewall.md
@@ -7,11 +7,3 @@ color: '#a4dfdc'
 You can configure your firewall to allow Kinopio as a trusted source by configuring host names to recognize any sub-domain of
 
 - `*.kinopio.club`
-- `https://kinopio-server.herokuapp.com`
-- `wss://kinopio-server.herokuapp.com`
-
-Also, these are the domains for Kinopio's external resources:
-
-- `https://files.kinopio.club/`
-- `https://kinopio-email.us-east-1.linodeobjects.com/`
-- `https://kinopio-uploads.us-east-1.linodeobjects.com/`


### PR DESCRIPTION
I recently stumbled upon this firewall doc and saw that it's outdated. It seems like all Kinopio related services now use a `*.kinopio.club` subdomain.

The only thing that we could add here is the 2 are.na addresses for which we also created runtime caches.

- `images.are.na`
- `d2w9rnfcy7mm78.cloudfront.net`